### PR TITLE
support local rss file

### DIFF
--- a/src/rss.rs
+++ b/src/rss.rs
@@ -247,7 +247,11 @@ pub fn subscribe_to_feed(
 }
 
 fn fetch_feed(http_client: &ureq::Agent, url: &str) -> Result<FeedAndEntries> {
-    let resp = http_client.get(url).call()?.into_string()?;
+    let resp = if !url.contains("http") {
+        std::fs::read_to_string(url).unwrap()
+    } else {
+        http_client.get(url).call()?.into_string()?
+    };
     let mut feed = FeedAndEntries::from_str(&resp)?;
     feed.set_feed_link(url);
 


### PR DESCRIPTION
Just a proof of concept.

At the moment of fetching the url, it checks if it contains "http" in the url. If it doesn't, it tries to load it as a file.

It's very simple but too rudimentary, a lot of things could go wrong (for example if a file name contain the word http), but it works for me with this small change.