### PR TITLE
Add shortcut for opening urls in entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1177,7 @@ dependencies = [
  "diligent-date-parser",
  "directories",
  "html2text",
+ "linkify",
  "num_cpus",
  "r2d2",
  "r2d2_sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ratatui = "0.20"
 ureq = "2.6"
 webbrowser = "0.8"
 wsl = "0.1"
+linkify = "0.10.0"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Some normal mode controls vary based on whether you are currently selecting a fe
 - `x` - refresh all feeds
 - `i` - change to insert mode
 - `a` - toggle between read/unread entries
-- `c` - copy the selected link to the clipboard (feed or entry)
-- `o` - open the selected link in your browser (feed or entry)
+- `c` - copy the selected link to the clipboard (feed or entry or references)
+- `o` - open the selected link in your browser (feed or entry or references)
+- `u` - find referenced/cited urls within current entry
 
 ### controls - insert mode
 

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -3,6 +3,7 @@ pub enum Selected {
     Feeds,
     Entries,
     Entry(crate::rss::EntryMeta),
+    References(crate::rss::EntryMeta),
     None,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
+use linkify::{LinkFinder, LinkKind};
 use ratatui::widgets::ListState;
+use std::sync::OnceLock;
 
 #[derive(Debug)]
 pub struct StatefulList<T> {
@@ -55,6 +57,21 @@ impl<T> From<Vec<T>> for StatefulList<T> {
     fn from(other: Vec<T>) -> Self {
         StatefulList::with_items(other)
     }
+}
+
+pub static LINK_FINDER: OnceLock<LinkFinder> = OnceLock::new();
+
+pub(crate) fn get_referenced_urls_from_text(text: &str) -> Vec<String> {
+    let finder = LINK_FINDER.get_or_init(|| {
+        let mut lf = LinkFinder::new();
+        lf.kinds(&[LinkKind::Url]);
+        lf
+    });
+
+    finder
+        .links(text)
+        .map(|link| link.as_str().to_string())
+        .collect()
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Pressing `u` from within an Entry view will now show a navigable list of urls extracted from that entry which can either be copied or opened in a browser with the `c` and `u` hotkeys.

fixes #21