### PR TITLE
implement ctrl-d and ctrl-u for page scrolling (#30)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -111,11 +111,11 @@ impl App {
             (KeyCode::Down, _) | (KeyCode::Char('j'), _) => self.on_down(),
             (KeyCode::Up, _) | (KeyCode::Char('k'), _) => self.on_up(),
             (KeyCode::Right, _) | (KeyCode::Char('l'), _) => self.on_right(),
-            (KeyCode::PageUp, _) => {
+            (KeyCode::PageUp, _) | (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
                 self.page_up();
                 Ok(())
             }
-            (KeyCode::PageDown, _) => {
+            (KeyCode::PageDown, _) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
                 self.page_down();
                 Ok(())
             }


### PR DESCRIPTION
Vim uses `Ctrl-u` and `Ctrl-d` for page up and page down scrolling. This PR adds this functionality to `russ`.

#30 