### PR TITLE
chore: use `AGPL-3.0-or-later` spdx id in cargo.toml and readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "russ"
 version = "0.5.0"
 authors = ["Clark Kampfe <clark.kampfe@gmail.com>"]
 edition = "2021"
+license = "AGPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -208,3 +208,4 @@ I welcome contributions to Russ. If you have an idea for something you would lik
 ## license
 
 See the [license.](LICENSE)
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
👋 I feel like `AGPL-3.0-or-later` better suits the project than `APGL-3.0-only`, correct me if I am wrong. Thanks!

closes https://github.com/ckampfe/russ/issues/41

cc @ckampfe 