### PR TITLE
Add g/G/C-o keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Some normal mode controls vary based on whether you are currently selecting a fe
 
 - `q`/`Esc` - quit Russ
 - `hjkl`/arrows - move up/down/left/right between feeds and entries, scroll up/down on an entry
+- `g`/`G` - move to top/bottom of the current entry or list
+- `ctrl-o` - return to previous place after jumping with `g`/`G`
 - `Enter` - read selected entry
 - `r` - refresh the selected feed
 - `r` - mark the selected entry as read

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,7 +58,6 @@ impl App {
         (on_up, Result<()>),
         (on_top, Result<()>),
         (on_bottom, Result<()>),
-        (restore_scroll, ()),
         (page_up, ()),
         (page_down, ()),
         (pop_feed_subscription_input, ()),
@@ -183,7 +182,6 @@ pub struct AppImpl {
     pub entry_selection_position: usize,
     pub current_entry_text: String,
     pub entry_scroll_position: u16,
-    pub saved_scroll_position: Option<u16>,
     pub entry_lines_len: usize,
     pub entry_lines_rendered_len: u16,
     pub entry_column_width: u16,
@@ -235,7 +233,6 @@ impl AppImpl {
             entries,
             selected,
             entry_scroll_position: 0,
-            saved_scroll_position: None,
             entry_lines_len: 0,
             entry_lines_rendered_len: 0,
             entry_column_width: 0,
@@ -634,7 +631,6 @@ impl AppImpl {
             }
             Selected::Entry(_) => {
                 self.entry_scroll_position = 0;
-                self.saved_scroll_position = None;
                 self.selected = {
                     self.current_entry_text = String::new();
                     Selected::Entries
@@ -724,7 +720,6 @@ impl AppImpl {
                 }
             }
             Selected::Entry(_) => {
-                self.saved_scroll_position = Some(self.entry_scroll_position);
                 self.entry_scroll_position = 0;
             }
             Selected::None => (),
@@ -747,28 +742,15 @@ impl AppImpl {
                 }
             }
             Selected::Entry(_) => {
-                self.saved_scroll_position = Some(self.entry_scroll_position);
                 self.entry_scroll_position = self
                     .entry_lines_len
-                    .checked_sub(self.entry_lines_rendered_len.into())
-                    .unwrap_or_default()
+                    .saturating_sub(self.entry_lines_rendered_len.into())
                     .saturating_sub(1) as u16;
             }
             Selected::None => (),
         }
 
         Ok(())
-    }
-
-    pub fn restore_scroll(&mut self) {
-        if let Some(saved) = self.saved_scroll_position.take() {
-            self.entry_scroll_position = saved.min(
-                self.entry_lines_len
-                    .checked_sub(self.entry_lines_rendered_len.into())
-                    .unwrap_or_default()
-                    .saturating_sub(1) as u16,
-            );
-        }
     }
 
     pub fn mode(&self) -> Mode {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::modes::{Mode, ReadMode, Selected};
 use crate::util;
 use anyhow::Result;
 use copypasta::{ClipboardContext, ClipboardProvider};
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::sync::{Arc, Mutex};
 
 macro_rules! delegate_to_locked_inner {
@@ -56,6 +56,9 @@ impl App {
         (on_left, Result<()>),
         (on_right, Result<()>),
         (on_up, Result<()>),
+        (on_top, Result<()>),
+        (on_bottom, Result<()>),
+        (restore_scroll, ()),
         (page_up, ()),
         (page_down, ()),
         (pop_feed_subscription_input, ()),
@@ -180,6 +183,7 @@ pub struct AppImpl {
     pub entry_selection_position: usize,
     pub current_entry_text: String,
     pub entry_scroll_position: u16,
+    pub saved_scroll_position: Option<u16>,
     pub entry_lines_len: usize,
     pub entry_lines_rendered_len: u16,
     pub entry_column_width: u16,
@@ -231,6 +235,7 @@ impl AppImpl {
             entries,
             selected,
             entry_scroll_position: 0,
+            saved_scroll_position: None,
             entry_lines_len: 0,
             entry_lines_rendered_len: 0,
             entry_column_width: 0,
@@ -595,7 +600,9 @@ impl AppImpl {
 
             #[cfg(not(target_os = "linux"))]
             {
-                unreachable!("This should never happen. This code should only be reachable if the target OS is WSL.")
+                unreachable!(
+                    "This should never happen. This code should only be reachable if the target OS is WSL."
+                )
             }
         } else if let Some(current_link) = current_link {
             let mut ctx = ClipboardContext::new().map_err(|e| anyhow::anyhow!(e))?;
@@ -627,6 +634,7 @@ impl AppImpl {
             }
             Selected::Entry(_) => {
                 self.entry_scroll_position = 0;
+                self.saved_scroll_position = None;
                 self.selected = {
                     self.current_entry_text = String::new();
                     Selected::Entries
@@ -700,6 +708,67 @@ impl AppImpl {
         }
 
         Ok(())
+    }
+
+    pub fn on_top(&mut self) -> Result<()> {
+        match self.selected {
+            Selected::Feeds => {
+                self.feeds.first();
+                self.update_current_feed_and_entries()?;
+            }
+            Selected::Entries => {
+                if !self.entries.items.is_empty() {
+                    self.entries.first();
+                    self.entry_selection_position = self.entries.state.selected().unwrap();
+                    self.update_current_entry_meta()?;
+                }
+            }
+            Selected::Entry(_) => {
+                self.saved_scroll_position = Some(self.entry_scroll_position);
+                self.entry_scroll_position = 0;
+            }
+            Selected::None => (),
+        }
+
+        Ok(())
+    }
+
+    pub fn on_bottom(&mut self) -> Result<()> {
+        match self.selected {
+            Selected::Feeds => {
+                self.feeds.last();
+                self.update_current_feed_and_entries()?;
+            }
+            Selected::Entries => {
+                if !self.entries.items.is_empty() {
+                    self.entries.last();
+                    self.entry_selection_position = self.entries.state.selected().unwrap();
+                    self.update_current_entry_meta()?;
+                }
+            }
+            Selected::Entry(_) => {
+                self.saved_scroll_position = Some(self.entry_scroll_position);
+                self.entry_scroll_position = self
+                    .entry_lines_len
+                    .checked_sub(self.entry_lines_rendered_len.into())
+                    .unwrap_or_default()
+                    .saturating_sub(1) as u16;
+            }
+            Selected::None => (),
+        }
+
+        Ok(())
+    }
+
+    pub fn restore_scroll(&mut self) {
+        if let Some(saved) = self.saved_scroll_position.take() {
+            self.entry_scroll_position = saved.min(
+                self.entry_lines_len
+                    .checked_sub(self.entry_lines_rendered_len.into())
+                    .unwrap_or_default()
+                    .saturating_sub(1) as u16,
+            );
+        }
     }
 
     pub fn mode(&self) -> Mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,9 @@ enum Action {
     MoveDown,
     MoveUp,
     MoveRight,
+    MoveTop,
+    MoveBottom,
+    RestoreScroll,
     PageUp,
     PageDown,
     RefreshAll,
@@ -304,6 +307,9 @@ fn get_action(app: &App, event: Event<KeyEvent>) -> Option<Action> {
                     (KeyCode::Right, _) | (KeyCode::Char('l'), _) => Some(Action::MoveRight),
                     (KeyCode::Down, _) | (KeyCode::Char('j'), _) => Some(Action::MoveDown),
                     (KeyCode::Up, _) | (KeyCode::Char('k'), _) => Some(Action::MoveUp),
+                    (KeyCode::Char('g'), _) => Some(Action::MoveTop),
+                    (KeyCode::Char('G'), _) => Some(Action::MoveBottom),
+                    (KeyCode::Char('o'), KeyModifiers::CONTROL) => Some(Action::RestoreScroll),
                     (KeyCode::PageUp, _) | (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
                         Some(Action::PageUp)
                     }
@@ -366,6 +372,9 @@ fn update(app: &mut App, action: Action) -> Result<()> {
         Action::MoveDown => app.on_down()?,
         Action::MoveUp => app.on_up()?,
         Action::MoveRight => app.on_right()?,
+        Action::MoveTop => app.on_top()?,
+        Action::MoveBottom => app.on_bottom()?,
+        Action::RestoreScroll => app.restore_scroll(),
         Action::PageUp => app.page_up(),
         Action::PageDown => app.page_down(),
         Action::ToggleHelp => app.toggle_help()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,6 @@ enum Action {
     MoveRight,
     MoveTop,
     MoveBottom,
-    RestoreScroll,
     PageUp,
     PageDown,
     RefreshAll,
@@ -309,7 +308,6 @@ fn get_action(app: &App, event: Event<KeyEvent>) -> Option<Action> {
                     (KeyCode::Up, _) | (KeyCode::Char('k'), _) => Some(Action::MoveUp),
                     (KeyCode::Char('g'), _) => Some(Action::MoveTop),
                     (KeyCode::Char('G'), _) => Some(Action::MoveBottom),
-                    (KeyCode::Char('o'), KeyModifiers::CONTROL) => Some(Action::RestoreScroll),
                     (KeyCode::PageUp, _) | (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
                         Some(Action::PageUp)
                     }
@@ -374,7 +372,6 @@ fn update(app: &mut App, action: Action) -> Result<()> {
         Action::MoveRight => app.on_right()?,
         Action::MoveTop => app.on_top()?,
         Action::MoveBottom => app.on_bottom()?,
-        Action::RestoreScroll => app.restore_scroll(),
         Action::PageUp => app.page_up(),
         Action::PageDown => app.page_down(),
         Action::ToggleHelp => app.toggle_help()?,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -403,7 +403,6 @@ fn draw_entry(f: &mut Frame, area: Rect, app: &mut AppImpl) {
 
     let paragraph = Paragraph::new(app.current_entry_text.as_str())
         .block(block)
-        .wrap(Wrap { trim: false })
         .scroll((scroll, 0));
 
     let entry_chunk_height = area.height - 2;

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,6 +44,14 @@ impl<T> StatefulList<T> {
         self.state.select(Some(i));
     }
 
+    pub fn first(&mut self) {
+        self.state.select(Some(0));
+    }
+
+    pub fn last(&mut self) {
+        self.state.select(Some(self.items.len() - 1));
+    }
+
     pub fn reset(&mut self) {
         self.state.select(Some(0));
     }


### PR DESCRIPTION
Adds the following keybinds:

- `g` to scroll to the top of a list/entry
- `G` to scroll to the bottom of a list/entry
- ~~`C-o` after scrolling to return to the point that the reader was at before using `g`/`G`~~
    - ~~I'm not 100% sure this is the best keybind for this operation.  `C-o` is the default in VIM, but most other commands don't use Ctrl.  Thoughts are welcome :)~~